### PR TITLE
Max idle connection time

### DIFF
--- a/lib/ezpool/connection_wrapper.rb
+++ b/lib/ezpool/connection_wrapper.rb
@@ -6,6 +6,7 @@ class EzPool::ConnectionWrapper
   def initialize(conn, connection_manager)
     @raw_conn = conn
     @created_at = EzPool.monotonic_time
+    @used_at = @created_at
     @manager = connection_manager
   end
 
@@ -16,5 +17,13 @@ class EzPool::ConnectionWrapper
 
   def age
     EzPool.monotonic_time - @created_at
+  end
+
+  def idle_time
+    EzPool.monotonic_time - @used_at
+  end
+
+  def touch_connection
+    @used_at = EzPool.monotonic_time
   end
 end


### PR DESCRIPTION
max_idle_time option could be used for connections which silently disconnect client in case of infrequent requests (like google cloud datastore)