### PR TITLE
feat: allow connection users to expire connections

### DIFF
--- a/lib/ezpool.rb
+++ b/lib/ezpool.rb
@@ -40,7 +40,7 @@ require_relative 'ezpool/connection_manager'
 # - :timeout - amount of time to wait for a connection if none currently available, defaults to 5 seconds
 # - :max_age - maximum number of seconds that a connection may be alive for (will recycle on checkin/checkout)
 # - :connect_with - callable for creating a connection
-# - :disconnect-_with - callable for shutting down a connection
+# - :disconnect_with - callable for shutting down a connection
 #
 class EzPool
   DEFAULTS = {size: 5, timeout: 1, max_age: Float::INFINITY}
@@ -125,16 +125,10 @@ end
       end
     end
 
-    @mutex.synchronize do
-      @checked_out_connections[conn_wrapper.raw_conn.object_id] = conn_wrapper
-    end
-    conn_wrapper.raw_conn
+    conn_wrapper
   end
 
-  def checkin(conn)
-    conn_wrapper = @mutex.synchronize do
-      @checked_out_connections.delete(conn.object_id)
-    end
+  def checkin(conn_wrapper)
     if conn_wrapper.nil?
       raise EzPool::CheckedInUnCheckedOutConnectionError
     end
@@ -155,6 +149,8 @@ end
 
   private
   def expired?(connection_wrapper)
+    return true if connection_wrapper.expired?
+
     if @max_age.finite?
       connection_wrapper.age > @max_age
     else

--- a/lib/ezpool.rb
+++ b/lib/ezpool.rb
@@ -3,6 +3,8 @@ require_relative 'ezpool/timed_stack'
 require_relative 'ezpool/errors'
 require_relative 'ezpool/connection_manager'
 
+require 'set'
+
 
 # Generic connection pool class for e.g. sharing a limited number of network connections
 # among many threads.  Note: Connections are lazily created.

--- a/lib/ezpool/connection_wrapper.rb
+++ b/lib/ezpool/connection_wrapper.rb
@@ -1,13 +1,21 @@
-require_relative 'monotonic_time'
+# frozen_string_literal: true
 
-class EzPool::ConnectionWrapper
+require_relative 'monotonic_time'
+require 'delegate'
+
+class EzPool::ConnectionWrapper < SimpleDelegator
   attr_reader :raw_conn
+  attr_reader :expired
+
+  alias expired? expired
 
   def initialize(conn, connection_manager)
-    @raw_conn = conn
     @created_at = EzPool.monotonic_time
     @manager = connection_manager
     @expired = false
+    @raw_conn = conn
+
+    super(conn)
   end
 
   # Shut down the connection. Can no longer be used after this!
@@ -20,6 +28,6 @@ class EzPool::ConnectionWrapper
   end
 
   def age
-    EzPool.monotonic_time - @created_at || @expired == true
+    EzPool.monotonic_time - @created_at
   end
 end

--- a/lib/ezpool/connection_wrapper.rb
+++ b/lib/ezpool/connection_wrapper.rb
@@ -7,6 +7,7 @@ class EzPool::ConnectionWrapper
     @raw_conn = conn
     @created_at = EzPool.monotonic_time
     @manager = connection_manager
+    @expired = false
   end
 
   # Shut down the connection. Can no longer be used after this!
@@ -14,7 +15,11 @@ class EzPool::ConnectionWrapper
     @manager.disconnect(@raw_conn)
   end
 
+  def expire!
+    @expired = true
+  end
+
   def age
-    EzPool.monotonic_time - @created_at
+    EzPool.monotonic_time - @created_at || @expired == true
   end
 end

--- a/lib/ezpool/timed_stack.rb
+++ b/lib/ezpool/timed_stack.rb
@@ -29,7 +29,6 @@ class EzPool::PoolShuttingDownError < RuntimeError; end
 #    #=> raises Timeout::Error after 5 seconds
 
 class EzPool::TimedStack
-
   ##
   # Creates a new pool with +size+ connections that are created by
   # constructing the given +connection_wrapper+ class

--- a/test/test_ezpool.rb
+++ b/test/test_ezpool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'helper'
 
 class TestEzPool < Minitest::Test
@@ -220,14 +222,14 @@ class TestEzPool < Minitest::Test
 
   def test_returns_value
     pool = EzPool.new(timeout: 0, size: 1) { Object.new }
-    assert_equal 1, pool.with {|o| 1 }
+    assert_equal 1, pool.with { |_o| 1 }
   end
 
   def test_checkin_garbage
     pool = EzPool.new(timeout: 0, size: 1) { Object.new }
 
-     assert_raises EzPool::CheckedInUnCheckedOutConnectionError do
-      pool.checkin Object.new
+    assert_raises EzPool::CheckedInUnCheckedOutConnectionError do
+      pool.checkin nil
     end
   end
 
@@ -236,7 +238,8 @@ class TestEzPool < Minitest::Test
 
     conn = pool.checkout
 
-    assert_kind_of NetworkConnection, conn
+    assert_kind_of EzPool::ConnectionWrapper, conn
+    assert_kind_of NetworkConnection, conn.raw_conn
 
     refute_same conn, pool.checkout
   end
@@ -444,7 +447,8 @@ class TestEzPool < Minitest::Test
     pool = EzPool.new(size: 1, connect_with: proc { conn_cls.new })
     
     pool.with do |conn|
-      assert_instance_of(conn_cls, conn)
+      assert_instance_of(EzPool::ConnectionWrapper, conn)
+      assert_instance_of(conn_cls, conn.raw_conn)
     end
   end
 
@@ -514,6 +518,20 @@ class TestEzPool < Minitest::Test
     pool.with { |r| r.do_work('with') }
     wrapper.do_work('wrapped')
 
-    assert_equal ['with', 'wrapped'], recorder.calls
+    assert_equal %w[with wrapped], recorder.calls
+  end
+
+  def test_ezpool_wrapper_manual_expiration
+    recorder = Recorder.new
+    pool = TestPool.new(size: 1) { recorder }
+
+    pool.with do |r|
+      r.do_work(r.object_id)
+      r.expire!
+    end
+
+    pool.with { |r| r.do_work(r.object_id) }
+
+    refute_equal(*recorder.calls)
   end
 end

--- a/test/test_ezpool.rb
+++ b/test/test_ezpool.rb
@@ -3,6 +3,9 @@
 require_relative 'helper'
 
 class TestEzPool < Minitest::Test
+  TestPool = Class.new(EzPool) do
+    attr_reader :available
+  end
 
   class NetworkConnection
     SLEEP_TIME = 0.1
@@ -225,11 +228,19 @@ class TestEzPool < Minitest::Test
     assert_equal 1, pool.with { |_o| 1 }
   end
 
-  def test_checkin_garbage
+  def test_checkin_nil
     pool = EzPool.new(timeout: 0, size: 1) { Object.new }
 
     assert_raises EzPool::CheckedInUnCheckedOutConnectionError do
       pool.checkin nil
+    end
+  end
+
+  def test_checkin_garbage
+    pool = EzPool.new(timeout: 0, size: 1) { Object.new }
+
+    assert_raises EzPool::CheckedInUnCheckedOutConnectionError do
+      pool.checkin Object.new
     end
   end
 


### PR DESCRIPTION
This allows connection owners to detect some application-specific condition that determines this connection is no longer valid.  When checked in, the pool will determine it is expired and abandon it.

In easy_stalk's case, we can more quickly move on to other servers when it is determined that there is no available work for the current server.

I think is approach is lighter weight and more flexible then #4 

This works by making the wrapper and decorator.